### PR TITLE
Add a messagepack parser.

### DIFF
--- a/lib/grape/msgpack.rb
+++ b/lib/grape/msgpack.rb
@@ -25,6 +25,14 @@ module Grape
         end
       end
     end
+
+    module Parser
+      class << self
+        def call(object, env)
+          MessagePack.unpack(object)
+        end
+      end
+    end
   end
 end
 
@@ -34,6 +42,10 @@ end
 
 class << Grape::ErrorFormatter::Base
   FORMATTERS[:msgpack] = Grape::Msgpack::ErrorFormatter
+end
+
+class << Grape::Parser::Base
+  PARSERS[:msgpack] = Grape::Msgpack::Parser
 end
 
 Grape::ContentTypes::CONTENT_TYPES[:msgpack] = 'application/x-msgpack'

--- a/spec/grape/msgpack_spec.rb
+++ b/spec/grape/msgpack_spec.rb
@@ -31,6 +31,13 @@ class MockAPI < Grape::API
   get :exception do
     raise StandardError, 'an error occurred'
   end
+
+  params do
+    requires :name, type: String
+  end
+  post :input do
+    present name: params.name
+  end
 end
 
 describe MockAPI do
@@ -71,5 +78,17 @@ describe MockAPI do
     it { expect(response.status).to eq(500) }
     it { expect(response.headers['Content-Type']).to eq('application/x-msgpack') }
     it { expect(MessagePack.unpack(response.body)).to eq('error' => 'an error occurred') }
+  end
+
+  describe 'POST /input' do
+    subject(:response) do
+      header 'Content-Type', 'application/x-msgpack'
+      post '/input', { name: 'joe' }.to_msgpack
+      last_response
+    end
+
+    it { expect(response.status).to eq 201 }
+    it { expect(response.headers['Content-Type']).to eq('application/x-msgpack') }
+    it { expect(MessagePack.unpack(response.body)).to eq('name' => 'joe') }
   end
 end


### PR DESCRIPTION
This will parse the request as msgpack if the `Content-Type` header is specified as `application/x-msgpack`.
