### PR TITLE
Handle arrays properly.

### DIFF
--- a/lib/grape/msgpack.rb
+++ b/lib/grape/msgpack.rb
@@ -40,9 +40,12 @@ Grape::ContentTypes::CONTENT_TYPES[:msgpack] = 'application/x-msgpack'
 
 if defined?(Grape::Entity)
   class Grape::Entity
-    def to_msgpack(options = {})
-      options = options.to_h if options && options.respond_to?(:to_h)
-      MessagePack.pack(serializable_hash(options))
+    def to_msgpack(pack = nil)
+      if pack
+        pack.write(serializable_hash)
+      else
+        MessagePack.pack(serializable_hash)
+      end
     end
   end
 end

--- a/spec/grape/msgpack_spec.rb
+++ b/spec/grape/msgpack_spec.rb
@@ -28,6 +28,10 @@ class MockAPI < Grape::API
     present MockModel.new('test_user', 21), with: MockEntity
   end
 
+  get :models do
+    present [MockModel.new('test_user', 21)], with: MockEntity
+  end
+
   get :exception do
     raise StandardError, 'an error occurred'
   end
@@ -60,6 +64,17 @@ describe MockAPI do
     it { expect(response.status).to eq(200) }
     it { expect(response.headers['Content-Type']).to eq('application/x-msgpack') }
     it { expect(MessagePack.unpack(response.body)).to eq('name' => 'test_user') }
+  end
+
+  describe 'GET /models' do
+    subject(:response) do
+      get '/models'
+      last_response
+    end
+
+    it { expect(response.status).to eq(200) }
+    it { expect(response.headers['Content-Type']).to eq('application/x-msgpack') }
+    it { expect(MessagePack.unpack(response.body).first).to eq('name' => 'test_user') }
   end
 
   describe 'GET /exception' do


### PR DESCRIPTION
When calling `to_msgpack` on an array of `Grape::Entity`'s, you would previously get the following error:

```
EOFError:
       end of buffer reached
```

msgpack-ruby will pass in a MessagePack::Pack instance as the first argument to `to_msgpack` which we can write additional content into.
