### PR TITLE
Use register API of formatters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
-gem 'grape', github: 'ruby-grape/grape'
+# gem 'grape', github: 'ruby-grape/grape'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+gem 'grape', github: 'ruby-grape/grape'

--- a/grape-msgpack.gemspec
+++ b/grape-msgpack.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 0.6.2'
   spec.add_development_dependency 'grape-entity', '~> 0.5.0'
 
-  spec.add_dependency 'grape'
+  spec.add_dependency 'grape', '>= 0.15.1'
   spec.add_dependency 'msgpack', '>= 0.7.4'
 end

--- a/grape-msgpack.gemspec
+++ b/grape-msgpack.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Grape::Msgpack::VERSION
   spec.authors       = ["Sho Kusano"]
   spec.email         = ["rosylilly@aduca.org"]
-  spec.summary       = %q{msgpack formatter for grape}
-  spec.description   = %q{msgpack formatter for grape}
+  spec.summary       = %q{Messagepack formatter for grape}
+  spec.description   = %q{Messagepack formatter for grape}
   spec.homepage      = ""
   spec.license       = "MIT"
 
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 2.14.1'
+  spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rack-test', '~> 0.6.2'
-  spec.add_development_dependency 'grape-entity', '~> 0.3.0'
+  spec.add_development_dependency 'grape-entity', '~> 0.5.0'
 
-  spec.add_dependency 'grape', '>= 0.6.0'
-  spec.add_dependency 'msgpack', '~> 0.5.6'
+  spec.add_dependency 'grape'
+  spec.add_dependency 'msgpack', '>= 0.7.4'
 end

--- a/grape-msgpack.gemspec
+++ b/grape-msgpack.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 0.6.2'
   spec.add_development_dependency 'grape-entity', '~> 0.5.0'
 
-  spec.add_dependency 'grape', '>= 0.15.1'
+  spec.add_dependency 'grape', '>= 0.16.1'
   spec.add_dependency 'msgpack', '>= 0.7.4'
 end

--- a/lib/grape/msgpack.rb
+++ b/lib/grape/msgpack.rb
@@ -36,17 +36,9 @@ module Grape
   end
 end
 
-class << Grape::Formatter::Base
-  FORMATTERS[:msgpack] = Grape::Msgpack::Formatter
-end
-
-class << Grape::ErrorFormatter::Base
-  FORMATTERS[:msgpack] = Grape::Msgpack::ErrorFormatter
-end
-
-class << Grape::Parser::Base
-  PARSERS[:msgpack] = Grape::Msgpack::Parser
-end
+Grape::Formatter.register(:msgpack, Grape::Msgpack::Formatter)
+Grape::ErrorFormatter.register(:msgpack, Grape::Msgpack::ErrorFormatter)
+Grape::Parser.register(:msgpack, Grape::Msgpack::Parser)
 
 Grape::ContentTypes::CONTENT_TYPES[:msgpack] = 'application/x-msgpack'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'coveralls'
 Coveralls.wear!
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end


### PR DESCRIPTION
from #3 . cc: @scalp42 

This PR is:
- Use `Formatter` instead of `Formatter::Base`
  - and `ErrorFormatter`, `Parser`
- Use `Formatter.register` instead of `FORMATTERS[]=`
  - and `ErrorFormatter`, `Parser`

This PR required merge https://github.com/ruby-grape/grape/pull/1330 . Waiting now.
